### PR TITLE
editPassword hecho, recovery arreglado, agregacion de validaciones

### DIFF
--- a/api/src/routes/recover.js
+++ b/api/src/routes/recover.js
@@ -52,8 +52,21 @@ router.post("/recuperar-contraseña", async (req, res) => {
 
 router.put("/password", async (req, res) => {
   const { newPassword, email } = req.body;
+
   try {
     const user = await UserModel.findOne({ email });
+
+    const passwordIsEqual = await bcrypt.compare(
+      newPassword.trim(),
+      user.password.trim()
+    );
+
+    if (passwordIsEqual) {
+      return res.status(BAD_REQUEST).json({
+        message: "Debes colocar una contraseña que no hayas usado antes",
+      });
+    }
+
     const saltRounds = 10;
     const hashedPassword = bcrypt.hashSync(newPassword, saltRounds);
     user.password = hashedPassword;

--- a/api/src/routes/user.js
+++ b/api/src/routes/user.js
@@ -219,6 +219,7 @@ router.post("/admin", adminMiddleware, async (req, res) => {
 
 router.put("/:id", async (req, res) => {
   const { userid } = req.headers;
+  console.log(req.body);
   try {
     const { id } = req.params;
     const image = req.files ? req.files.image : null;
@@ -234,16 +235,24 @@ router.put("/:id", async (req, res) => {
       lastName,
       email,
       bio,
-      password,
+      newPassword,
+      oldPassword,
       bougthBeats,
     } = req.body;
     const userin = await UserModel.findById(id);
     const userAux = await UserModel.findById(userid);
+    console.log("userin >", userin, "userAux >", userAux);
+
+    const passwordIsValid = await bcrypt.compare(
+      oldPassword.trim(),
+      userin.password.trim()
+    );
+
     if (!userin)
       return res
         .status(400)
         .json({ message: "El usuario que quieres actualizar no existe" });
-    if (userin.email !== userAux.email)
+    if (userin?.email !== userAux?.email)
       return res
         .status(400)
         .json({ message: "No puedes actualizar otro usuario!" });
@@ -254,6 +263,16 @@ router.put("/:id", async (req, res) => {
     ) {
       return res.status(BAD_REQUEST).send(ALL_NOT_OK);
     }
+    if (!passwordIsValid) {
+      return res.status(BAD_REQUEST).json({
+        message: "La contraseña no coincide con tu contraseña actual",
+      });
+    } else if (oldPassword && newPassword && oldPassword === newPassword) {
+      return res
+        .status(BAD_REQUEST)
+        .json({ message: "La nueva contraseña debe ser distinta a la actual" });
+    }
+
     if (
       favorite ||
       backImage ||
@@ -266,7 +285,8 @@ router.put("/:id", async (req, res) => {
       lastName ||
       email ||
       bio ||
-      password ||
+      newPassword ||
+      oldPassword ||
       bougthBeats
     ) {
       const user = await UserModel.findById(id);
@@ -274,7 +294,7 @@ router.put("/:id", async (req, res) => {
         if (!user.userFavorites.includes(favorite)) {
           user.userFavorites = [...user.userFavorites, favorite];
         } else {
-          const index = user.userFavorites.findIndex(e => e = favorite);
+          const index = user.userFavorites.findIndex((e) => (e = favorite));
           user.userFavorites = user.userFavorites.slice(index, index);
         }
       }
@@ -283,9 +303,9 @@ router.put("/:id", async (req, res) => {
       if (lastName && lastName !== "") user.lastName = lastName;
       if (email && email !== "") user.email = email;
       if (bio && bio !== "") user.bio = bio;
-      if (password && password !== "") {
+      if (newPassword && newPassword !== "") {
         const saltRounds = 10;
-        const hashedPassword = bcrypt.hashSync(password, saltRounds);
+        const hashedPassword = bcrypt.hashSync(newPassword, saltRounds);
         user.password = hashedPassword;
       }
       if (image) {
@@ -416,7 +436,7 @@ router.put("/admin/:id", adminMiddleware, async (req, res) => {
         if (!user.userFavorites.includes(favorite)) {
           user.userFavorites = [...user.userFavorites, favorite];
         } else {
-          const index = user.userFavorites.findIndex(e => e = favorite);
+          const index = user.userFavorites.findIndex((e) => (e = favorite));
           user.userFavorites = user.userFavorites.slice(index, index);
         }
       }

--- a/client/src/components/forms/editPasswordForm.js
+++ b/client/src/components/forms/editPasswordForm.js
@@ -17,13 +17,13 @@ export default function EditPasswordForm(props) {
   const [fieldsToValidate, setFieldsToValidate] = useState([]);
   const [error, setErrors] = useState({});
 
-  const defaultValues =
-    useSelector((state) => state.client.authSession.session.current) || {};
-  const id = useSelector(
-    (state) => state.client.authSession.session.current._id
-  );
+  // const defaultValues =
+  //   useSelector((state) => state.client.authSession.session.current) || {};
+  // const id = useSelector(
+  //   (state) => state.client.authSession.session.current._id
+  // );
 
-  const mode = props.mode;
+  // const mode = props.mode;
 
   const [form, setForm] = useState({
     oldPassword: "",
@@ -46,7 +46,7 @@ export default function EditPasswordForm(props) {
         console.log("DESPACHADO", form);
         await dispatch(editClient(form));
         formRef.current.reset();
-        router.push("/client");
+        // router.push("/client");
       } else {
         setErrors(formErrors);
         console.log("form Error", formErrors);

--- a/client/src/components/forms/recoveryPasswordForm.js
+++ b/client/src/components/forms/recoveryPasswordForm.js
@@ -12,6 +12,7 @@ export default function RecoveryPasswordForm(props) {
   const validateMode = "user";
   const [fieldsToValidate, setFieldsToValidate] = useState([]);
   const [error, setErrors] = useState({});
+  const userEmail = router.query.email;
 
   const id = useSelector(
     (state) => state.client.authSession.session.current._id
@@ -36,9 +37,11 @@ export default function RecoveryPasswordForm(props) {
     try {
       const formErrors = validationRecoverPassword(form, "*");
       if (Object.keys(formErrors).length === 0) {
-        console.log("DESPACHADO", form);
-        dispatch(passwordRecovery(form));
-        // formRef.current.reset();
+        console.log("DESPACHADO", {});
+        dispatch(
+          passwordRecovery({ newPassword: form.newPassword, email: userEmail })
+        );
+        formRef.current.reset();
         // router.push("/auth");
       } else {
         setErrors(formErrors);

--- a/client/src/components/validation/client/editPassword.js
+++ b/client/src/components/validation/client/editPassword.js
@@ -1,27 +1,34 @@
 export function validationEditPassword(form, fieldsToValidate) {
   let error = {};
-  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-  const regexImage = /\.jpg$|\.png$/i;
   const regexPassword =
     /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
-  const regexEmail = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
   if (fieldsToValidate === "*") {
     //pasamos de object a array
     fieldsToValidate = Object.keys(form);
   }
 
+  // oldRegisteredPassword = getState().client.authSession.session.CONTRASEÑA
+
   fieldsToValidate.forEach((field) => {
     switch (field) {
       case "oldPassword":
-        if (!regexPassword.test(form.oldPassword))
+        if (!regexPassword.test(form.oldPassword)) {
           error.oldPassword =
             "La contraseña debe contener al menos una letra mayúscula, una letra minúscula, un número y un caracter especial; ademas de  un mínimo de 8 caracteres";
+        } //  else if (form.oldPassword !== /* CONTRASEÑA */ 1) {
+        // //   error.oldPassword =
+        //     "Esta contraseña no coincide con tu contraseña actual";
+        // }
         break;
       case "newPassword":
         if (!regexPassword.test(form.newPassword))
           error.newPassword =
             "La contraseña debe contener al menos una letra mayúscula, una letra minúscula, un número y un caracter especial; ademas de  un mínimo de 8 caracteres";
+        // else if (form.oldPassword === form.newPassword) {
+        //   error.newPassword =
+        //     "Tu nueva contraseña debe ser distinta a la actual";
+        // }
         break;
 
       default:

--- a/client/src/redux/slices/client/authSession.js
+++ b/client/src/redux/slices/client/authSession.js
@@ -15,7 +15,6 @@ import { setBougthBeats, setOwnedBeats, setFavoriteBeats } from "./beats";
 import { setOwnedReviews } from "./reviews";
 import { setOrders } from "./orders";
 
-
 const initialState = {
   auth: {
     isLogged: false,
@@ -133,23 +132,21 @@ export const editClient = createAsyncThunk(
   "authSession/editClient",
   async (data, { rejectWithValue, getState }) => {
     const clientId = getState().client.authSession.session.current._id;
-    const formData = new FormData();
-    Object.keys(data).forEach((key) => {
-      formData.append(key, data[key]);
-    });
+    // const formData = new FormData();
+    // Object.keys(data).forEach((key) => {
+    //   formData.append(key, data[key]);
+    // });
+    // ESTO ESTA COMENTADO PORQUE LO PROBE Y NO ME ANDABA,
+    // El consoleLog de "formData" era un objeto vacio mientras que "Data" tenia los datos
 
     try {
       console.log("prev", data, clientId);
-      const response = await axios.put(
-        `${serverUrl}user/${clientId}`,
-        formData,
-        {
-          headers: {
-            userid: clientId,
-            "Content-Type": "multipart/form-data",
-          },
-        }
-      );
+      const response = await axios.put(`${serverUrl}user/${clientId}`, data, {
+        headers: {
+          userid: clientId,
+          "Content-Type": "multipart/form-data",
+        },
+      });
 
       const userResponse = createUserSession(response.data);
       return { userResponse };
@@ -161,21 +158,17 @@ export const editClient = createAsyncThunk(
 
 //--------------------
 //PASSWORD RECOVERY
-// export const passwordRecovery = createAsyncThunk(
-//   "authSession/passwordRecovery",
-//   async (data, { rejectWithValue }) => {
-//     const clientId = "64459913669bbb0d6e7838d9"; //Id de fabi durante testeo (hecho por fabi)
-
-//     try {
-//       const newPassword = { password: data.newPassword };
-
-//       await axios.put(`${serverUrl}user/${clientId}`, newPassword);
-//     } catch (error) {
-//       console.log("ERROR passwordRecovery", error);
-//       return rejectWithValue(error.response.data.message);
-//     }
-//   }
-// );
+export const passwordRecovery = createAsyncThunk(
+  "authSession/passwordRecovery",
+  async (data, { rejectWithValue }) => {
+    try {
+      await axios.put(`${serverUrl}recover/password`, data);
+    } catch (error) {
+      console.log("ERROR passwordRecovery", error);
+      return rejectWithValue(error.response.data.message);
+    }
+  }
+);
 
 //--------------------
 //GET USER DATA
@@ -198,7 +191,6 @@ export const getUserData = createAsyncThunk(
       const orders = response.userOrders;
       //const favoriteBeats = response.favoriteBeats;
 
-
       console.log(
         "bougthBeats",
         bougthBeats,
@@ -212,7 +204,7 @@ export const getUserData = createAsyncThunk(
       await dispatch(setBougthBeats(bougthBeats));
       await dispatch(setOwnedBeats(ownedBeats));
       await dispatch(setOwnedReviews(ownedReviews));
-     await dispatch(setOrders(orders));
+      await dispatch(setOrders(orders));
       //await dispatch(setFavoriteBeats(favoriteBeats));
 
       const auth = {
@@ -318,20 +310,20 @@ const authSession = createSlice({
         toast.success("Se editó correctamente", toastSuccess);
       })
       .addCase(editClient.rejected, (state, action) => {
-        console.log("editClient.rejected", action.error);
+        console.log("editClient.rejected", action.payload);
         toast.error(action.payload, toastError);
       })
 
       /***************** PASSWORD RECOVERY ******************/
-      // .addCase(passwordRecovery.pending, (state, action) => {
-      //   return;
-      // })
-      // .addCase(passwordRecovery.fulfilled, (state, action) => {
-      //   toast.success("Tu contraseña se cambio correctamente", toastSuccess);
-      // })
-      // .addCase(passwordRecovery.rejected, (state, action) => {
-      //   toast.error("Hubo un problema, intente mas tarde", toastError);
-      // })
+      .addCase(passwordRecovery.pending, (state, action) => {
+        return;
+      })
+      .addCase(passwordRecovery.fulfilled, (state, action) => {
+        toast.success("Tu contraseña se cambio correctamente", toastSuccess);
+      })
+      .addCase(passwordRecovery.rejected, (state, action) => {
+        toast.error(action.payload, toastError);
+      })
 
       //--------------------
       //GET USER DATA


### PR DESCRIPTION
La pestaña para cambiar contraseña desde el perfil ahora es completamente funcional, valida: 
-si "contraseña vieja" es igual a la que esta en la base de datos, sino devuelve un toast avisandole al usuario que la contraseña colocada no coincide con la contraseña vieja(actual)
-si ambas contaseñas (nueva y vieja) son iguales te avisa mediante un toast que tienen que ser distintas para poder realizar el cambio, de lo contrario te permite hacer el cambio

agregue cosas del passwordRecovery que no se mergearon correctamente en el PR anterior

agregue validaciones al form de passwordRecovery para que:
-Si el usuario intenta cambiar la contraseña a la misma que ya tiene, le avisa mediante un toast que debe cambiar su contraseña a una que no haya usado antes